### PR TITLE
fix: Renaming leftover 'AccountServer' to 'AccountController' to comply the changes in the last 2 commits

### DIFF
--- a/src/Classes/Classes.js
+++ b/src/Classes/Classes.js
@@ -173,12 +173,12 @@ class VVMatch {
 	}
 
 	groupSearchStart(sessionID, info) {
-		let myAccount = AccountServer.find(sessionID);
+		let myAccount = AccountController.find(sessionID);
 		if(myAccount.matching === undefined) myAccount.matching = {};
 		myAccount.matching.lookingForGroup = true;
 	}
 	groupSearchStop(sessionID, info) {
-		let myAccount = AccountServer.find(sessionID);
+		let myAccount = AccountController.find(sessionID);
 		if(myAccount.matching === undefined) myAccount.matching = {};
 		myAccount.matching.lookingForGroup = false;
 	}


### PR DESCRIPTION
The group search functions are still using 'AccountServer', which seems to be removed the recent commits on the TarkovServer repo, causing the mod will fail to load due to the missing reference. Now the mod should be able to load.